### PR TITLE
[openmp] improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 venv/
 
 examples/*.log
+data/flight_delay.csv.gz
 **/*.so
 build/
+python-package/dist/
+python-package/microgbtpy.egg-info/
 cmake-build-debug/
 pybind11/
 CMakeCache.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - cmake ..
   - cmake --build .
   - ctest
-  - valgrind --leak-check=full --track-fds=yes --error-exitcode=1 ./bin/unit_tests
+  - valgrind --leak-check=full --track-fds=yes --track-origins=yes --leak-check=full --show-leak-kinds=definite,indirect --error-exitcode=1 ./bin/unit_tests
   - ./bin/unit_tests
 
 after_success:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,8 +21,31 @@ FIND_PACKAGE (Eigen3 3.3 REQUIRED NO_MODULE)
 
 
 # Based on https://iscinumpy.gitlab.io/post/omp-on-high-sierra/
+# and for Mojave 10.14: see https://github.com/microsoft/LightGBM/pull/1919
 if(USE_OPENMP)
-    FIND_PACKAGE(OpenMP REQUIRED)
+    find_package(OpenMP)
+
+    # If OpenMP wasn't found, try if we can find it in the default Homebrew location
+    if((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND) AND EXISTS "/usr/local/opt/libomp/lib/libomp.dylib")
+        set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include")
+        set(OpenMP_C_LIB_NAMES omp)
+        set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I/usr/local/opt/libomp/include")
+        set(OpenMP_CXX_LIB_NAMES omp)
+        set(OpenMP_omp_LIBRARY /usr/local/opt/libomp/lib/libomp.dylib)
+
+        find_package(OpenMP)
+        if (OPENMP_FOUND OR OPENMP_CXX_FOUND)
+            message(STATUS "Found libomp in homebrew default location.")
+        else()
+            message(FATAL_ERROR "Didn't find libomp. Tried homebrew default location but also didn't find it.")
+        endif()
+    endif()
+
+    if((NOT OPENMP_FOUND) AND (NOT OPENMP_CXX_FOUND))
+        message(FATAL_ERROR "Did not find OpenMP.")
+    endif()
+
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 else()
     # Ignore unknown #pragma warning
     if((CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
@@ -59,6 +82,7 @@ set(MemoryCheckCommand /usr/bin/valgrind)
 set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --leak-check=full")
 set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --track-fds=yes")
 set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --trace-children=yes")
+set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --track-origins=yes")
 set(MEMORYCHECK_COMMAND_OPTIONS "${MEMORYCHECK_COMMAND_OPTIONS} --error-exitcode=1")
 
 include(cmake/googletest.cmake)

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,4 +1,12 @@
 
+## Python wheels packaging
+
+```bash
+python setup.py bdist_wheel
+ls dist/
+microgbtpy-0.0.1-cp36-cp36m-macosx_10_13_x86_64.whl
+```
+
 ## To count lines of code 
 
 Type, (`brew install cloc` to install cloc)

--- a/examples/test-flight.py
+++ b/examples/test-flight.py
@@ -30,7 +30,7 @@ def binclass_metrics(gbt, X, y_true, label, show_report = False):
 def load_flight_delay():
     logger.info("Loading flights data...")
     dataset = "flight"
-    URL = "data/flight_delay.csv.gz"
+    URL = "../data/flight_delay.csv.gz"
     logger.debug("Using dataset {} from {}".format(dataset, URL))
     features = pd.read_csv(URL)
 
@@ -74,9 +74,10 @@ params = {
     "max_depth": 4.0,
     "shrinkage_rate": 1.0,
     "min_split_gain": 0.1,
-    "learning_rate": 0.1,
     "min_tree_size": 3,
-    "num_boosting_rounds": 100.0
+    "learning_rate": 0.1,
+    "num_boosting_rounds": 100.0,
+    "metric": 0
 }
 
 # Define the GBT

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -1,10 +1,21 @@
-from setuptools import setup
+from setuptools import setup, Extension
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
 
 __version__ = "0.0.1"
 
+# Based on https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it
+class BdistWheel(_bdist_wheel):
+    def finalize_options(self):
+        _bdist_wheel.finalize_options(self)
+        self.root_is_pure = False
+
+
 setup(
     name="microgbtpy",
+    version=__version__,
     author="Anastasios Zouzias",
+    url="https://github.com/zouzias/microgbt",
     description="microgbt is a minimalistic Gradient Boosting Trees implementation",
     license="Apache 2.0 license",
     classifiers=[
@@ -15,12 +26,11 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
     ],
+    cmdclass={'bdist_wheel': BdistWheel},
     include_package_data=True,
     keywords="gradient boosting trees",
-    url="https://github.com/zouzias/microgbt",
     zip_safe=False,
-    version=__version__,  # specified elsewhere
     packages=[""],
     package_dir={"": "."},
-    package_data={"": ["microgbtpy.cpython-*-darwin.so"]},
+    package_data={"": ["microgbtpy.cpython-*.so"]},
 )

--- a/runBuild.sh
+++ b/runBuild.sh
@@ -12,17 +12,8 @@ fi
 rm -rf bin/
 rm -rf build/
 mkdir build/
-pushd build
+pushd build || exit
 cmake ..
-make
-popd
+popd || exit
 
-# Copy .so library to python-package
-cp build/lib/*.so ./python-package/
-
-
-# Install microgbtpy as a Python package
-pushd ./python-package/
-pip install sklearn pandas
-pip install -U .
-popd
+./runMake.sh

--- a/runMake.sh
+++ b/runMake.sh
@@ -2,7 +2,7 @@
 
 # Run make and copy shared library to examples
 
-pushd build
+pushd build || exit
 make
 # Copy .so library to examples for Python testing
 cp lib/*.so ../python-package/
@@ -11,4 +11,9 @@ popd
 pushd ./python-package/
 pip install sklearn pandas
 pip install -U .
+popd
+
+# Run titanic example
+pushd ./examples/
+./test-titanic.py
 popd

--- a/src/GBT.h
+++ b/src/GBT.h
@@ -8,6 +8,7 @@
 #include "metrics/metric.h"
 #include "metrics/logloss.h"
 #include "metrics/rmse.h"
+#include <chrono>
 
 
 namespace microgbt {
@@ -116,6 +117,9 @@ namespace microgbt {
             // Allow nested threading in OpenMP
             omp_set_nested(1);
 
+            // Only 2 active levels of nested parallelism
+            // omp_set_max_active_levels(2);
+
             std::vector<Tree> trees;
             long bestIteration = 0;
             double learningRate = _shrinkageRate;
@@ -125,16 +129,20 @@ namespace microgbt {
             for (long iterCount = 0; iterCount < numBoostRound; iterCount++) {
 
                 std::cout << "Iteration: " << iterCount << std::endl;
+                auto startTimestamp = std::chrono::high_resolution_clock::now();
 
                 // Current predictions
                 Vector scores = predictDatasetFromTrees(trainSet, trees);
 
                 // Compute gradient and Hessian with respect to prior predictions
+                std::cout << "Computing gradients/Hessians" << std::endl;
                 Vector gradient = _metric->gradients(scores, trainSet.y());
                 Vector hessian = _metric->hessian(scores);
 
                 // Grow a new tree learner
+                std::cout << "Building next tree" << std::endl;
                 Tree tree = buildTree(trainSet, scores, gradient, hessian, learningRate);
+                std::cout << "Tree is built" << std::endl;
 
                 // Update the learning rate
                 learningRate *= _learningRate;
@@ -143,12 +151,17 @@ namespace microgbt {
                 trees.push_back(tree);
 
                 // Update train and validation loss
+                std::cout << "Evaluating training / validation loss" << std::endl;
                 Vector trainPreds = predictDatasetFromTrees(trainSet, trees);
                 double trainLoss = _metric->lossAt(trainPreds, trainSet.y());
                 Vector validPreds = predictDatasetFromTrees(validSet, trees);
                 double currentValidationLoss = _metric->lossAt(validPreds, validSet.y());
 
-                std::cout << "[Train Loss]: " << trainLoss << " | [Valid Loss]: " << bestValidationLoss <<std::endl;
+                auto endTimestamp = std::chrono::high_resolution_clock::now();
+                auto duration = std::chrono::duration_cast<std::chrono::milliseconds>( endTimestamp - startTimestamp ).count();
+                std::cout << "[Duration: " << duration << " millis][Train Loss]: " << trainLoss
+                    << " | [Valid Loss]: " << bestValidationLoss <<std::endl;
+
 
                 // Update best iteration / best validation error
                 if (currentValidationLoss < bestValidationLoss) {
@@ -207,7 +220,6 @@ namespace microgbt {
         double predictFromTrees(const Eigen::RowVectorXd &x, const std::vector<Tree> &trees) const {
             size_t n = trees.size();
             double score = 0.0;
-            #pragma omp parallel for default(none) shared(n, x, trees) reduction(+: score)
             for (size_t i = 0; i < n; i ++){
                 score += trees[i].score(x);
             }
@@ -217,7 +229,7 @@ namespace microgbt {
         Vector predictDatasetFromTrees(const Dataset &trainSet, const std::vector<Tree> &trees) const {
             size_t numSamples = trainSet.nRows();
             Vector scores(numSamples);
-            #pragma omp parallel for schedule(static)
+            #pragma omp parallel for schedule(static, 1024)
             for (size_t i = 0; i < numSamples; i++) {
                 scores[i] = predictFromTrees(trainSet.row(i), trees);
             }

--- a/src/dataset.h
+++ b/src/dataset.h
@@ -2,11 +2,14 @@
 #include <vector>
 #include<iostream>
 #include <Eigen/Dense>
+#include <numeric>
 #include "trees/split_info.h"
 
 namespace microgbt {
 
     using Vector = std::vector<double>;
+    using MatrixType = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
+    using SortedMatrixType = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::ColMajor>;
 
     /**
     * Represents a machine learning "design matrix" and target vector, (X, y)
@@ -19,17 +22,51 @@ namespace microgbt {
         /**
          * Design matrix, each row correspond to a sample; each column corresponds to a feature
          */
-        Eigen::MatrixXd _X;
+        MatrixType _X;
+
+
+        /**
+         * Matrix whose columns contain the
+         */
+        SortedMatrixType _sortedColumnValues;
 
         /**
          * Target vector
          */
         Vector _y;
+
+        /**
+         * Return sorted indices from an Eigen vector
+         * @param v
+         * @return
+         */
+         Eigen::VectorXi sortIndices(int colIndex) const{
+
+            // initialize original index locations
+            Eigen::VectorXd v = _X.col(colIndex);
+            unsigned int n = v.size();
+
+            Eigen::VectorXi idx(n);
+            // idx contains now 0,1,...,v.size() - 1
+            std::iota(idx.data(), idx.data() + idx.size(), 0);
+
+            // sort indexes based on comparing values in v
+            std::sort(idx.data(), idx.data() + idx.size(),
+                 [&v](int i1, int i2) {return v[i1] < v[i2];});
+
+            return idx;
+        }
+
     public:
 
         Dataset() = default;
 
-        Dataset(const Eigen::MatrixXd& X, const Vector& y): _X(X), _y(y) {
+        Dataset(const MatrixType &X, Vector &y) : _X(X), _sortedColumnValues(X.rows(), X.cols()), _y(y) {
+
+            // Compute sorted indices per column
+            for (int j = 0; j < X.cols(); j++) {
+                _sortedColumnValues.col(j) = sortIndices(j);
+            }
         }
 
 
@@ -41,26 +78,28 @@ namespace microgbt {
          * @param bestGain
          * @param side
          */
-        Dataset(Dataset const &dataset, const SplitInfo& bestGain, SplitInfo::Side side) {
+        Dataset(Dataset const &dataset, const SplitInfo &bestGain, SplitInfo::Side side): _y(dataset.y()) {
 
             std::vector<size_t> rowIndices;
             if (side == SplitInfo::Side::Left) {
                 rowIndices = bestGain.getLeftIds();
-            }
-            else {
+            } else {
                 rowIndices = bestGain.getRightIds();
             }
 
             int rowSize = rowIndices.size(), colSize = dataset.numFeatures();
 
-            _y = Vector(dataset.y());
-            _X = Eigen::MatrixXd(rowSize, colSize);
+            _X = MatrixType(rowSize, colSize);
+            _sortedColumnValues = SortedMatrixType(rowSize, _X.cols());
 
-            #pragma omp parallel for schedule(static)
             for (size_t i = 0; i < rowIndices.size(); i++) {
-                for (int j = 0 ; j < colSize; j++) {
-                    _X(i, j) = dataset.X()(rowIndices[i], j);
-                }
+                _X.row(i) = dataset.row(rowIndices[i]);
+            }
+
+            // Compute sorted indices per column
+            #pragma omp parallel for schedule(static)
+            for (int j = 0; j < colSize; j++) {
+                _sortedColumnValues.col(j) = sortIndices(j);
             }
         }
 
@@ -72,20 +111,21 @@ namespace microgbt {
             return this->_X.cols();
         }
 
-        Vector y() const {
+        inline Vector y() const {
             return _y;
         }
 
-        Eigen::MatrixXd X() const {
-            return _X;
-        }
-
-        Eigen::RowVectorXd row(long rowIndex) const {
+        inline Eigen::RowVectorXd row(long rowIndex) const {
             return _X.row(rowIndex);
         }
 
-        Eigen::RowVectorXd col(long colIndex) const {
-            return _X.col(colIndex);
+        /**
+         * Returns a sorted vector of indices corresponding to a column
+         * @param colIndex Index of column
+         * @return
+         */
+        inline Eigen::RowVectorXi sortedColumnIndices(long colIndex) const {
+            return _sortedColumnValues.col(colIndex);
         }
     };
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(
     unit_tests
     gtest_main
     microgbt
+    OpenMP::OpenMP_CXX
     )
 
 add_test(

--- a/test/test_dataset.cpp
+++ b/test/test_dataset.cpp
@@ -4,8 +4,8 @@
 TEST(Dataset, DefaultConstructor)
 {
 
-    size_t m = 2, n = 3;
-    Eigen::MatrixXd A(m, n);
+    int m = 2, n = 3;
+    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(m, n);
     microgbt::Vector y = {1.0, 2.0, 3.0};
     microgbt::Dataset dataset(A, y);
 
@@ -16,8 +16,8 @@ TEST(Dataset, DefaultConstructor)
 TEST(Dataset, Constructor)
 {
 
-    size_t m = 2, n = 3;
-    Eigen::MatrixXd A(m, n);
+    int m = 2, n = 3;
+    Eigen::MatrixXd A = Eigen::MatrixXd::Zero(m, n);
     microgbt::Vector y = {1.0, 2.0, 3.0};
     microgbt::Dataset dataset(A, y);
 


### PR DESCRIPTION
[examples] add flight delays

Dataset improvements (#5)

* [datasest] WIP

* [valgrind] track--origins

* [scripts] run titanic example after buil/make

* [dataset] clean up

* [dataset] avoid extra copy

* [dataset] fix sortIndices valgrind

* [dataset] vectorize constructor

* [dataset] avoid more copies

* [travis] add --track-origins=yes in valgrind

* [dataset] avoid more for loops

* [tests] make valgrind happy

[openmp] init commit

[travis] run unit tests

[notes] update for openmp

[openmp] hotfix

[logging] log elapsed times per tree

[travis] show all leak info

[travis] valgrind do not show reachable leaks