### PR TITLE
Force Python3 libs in Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Look for eigen 3.3
 FIND_PACKAGE (Eigen3 3.3 REQUIRED NO_MODULE)
 
+# Find Python3
+find_package (Python3 COMPONENTS Interpreter Development)
 
 # place binaries and libraries according to GNU standards
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,10 @@ SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # Look for eigen 3.3
 FIND_PACKAGE (Eigen3 3.3 REQUIRED NO_MODULE)
 
-# Find Python3
+# Force to make use of Python3
+set(Python_ADDITIONAL_VERSIONS 3.6)
 find_package (Python3 COMPONENTS Interpreter Development)
+find_package(PythonLibs 3 REQUIRED)
 
 # place binaries and libraries according to GNU standards
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,7 @@ include_directories( ${EIGEN3_INCLUDE_DIRS} )
 # For Python integration
 add_subdirectory(pybind11)
 
-pybind11_add_module(microgbtpy src/metrics/metric.h src/trees/tree.h src/GBT.h src/dataset.h src/metrics/logloss.h
+pybind11_add_module(microgbtpy MODULE src/metrics/metric.h src/trees/tree.h src/GBT.h src/dataset.h src/metrics/logloss.h
         src/trees/treenode.h src/trees/split_info.h
         src/python_api.cpp)
 #########################

--- a/dev-scripts/runInstallPyPackage.sh
+++ b/dev-scripts/runInstallPyPackage.sh
@@ -11,7 +11,7 @@ ls -lah lib/
 popd
 
 
-sudo pip uninstall -y microgbtpy
+python3 -m pip install --user --upgrade pip
 
 pushd python-package/
 pip3 install --user sklearn pandas

--- a/dev-scripts/runInstallPyPackage.sh
+++ b/dev-scripts/runInstallPyPackage.sh
@@ -14,6 +14,6 @@ popd
 sudo pip uninstall -y microgbtpy
 
 pushd python-package/
-pip3 install sklearn pandas
-sudo python3 setup.py build_ext install
+pip3 install --user sklearn pandas
+python3 setup.py build_ext install --user
 popd

--- a/dev-scripts/runInstallPyPackage.sh
+++ b/dev-scripts/runInstallPyPackage.sh
@@ -10,6 +10,9 @@ cp lib/*.so ../python-package/
 ls -lah lib/
 popd
 
+
+sudo pip uninstall -y microgbtpy
+
 pushd python-package/
 pip3 install sklearn pandas
 sudo python3 setup.py install

--- a/dev-scripts/runInstallPyPackage.sh
+++ b/dev-scripts/runInstallPyPackage.sh
@@ -15,5 +15,5 @@ sudo pip uninstall -y microgbtpy
 
 pushd python-package/
 pip3 install sklearn pandas
-sudo python3 setup.py install
+sudo python3 setup.py build_ext install
 popd

--- a/python-package/setup.py
+++ b/python-package/setup.py
@@ -37,6 +37,7 @@ setup(
     setup_requires=setup_requirements,
     test_suite='tests',
     zip_safe=False,
+    packages=find_packages(),
     package_dir={"": "."},
     package_data={"": ["microgbtpy*.so"]},
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,8 @@
-add_library(microgbt "" metrics/metric.h trees/tree.h trees/split_info.h
+add_library(microgbt STATIC metrics/metric.h trees/tree.h trees/split_info.h
         GBT.h dataset.h metrics/logloss.h trees/treenode.h metrics/rmse.h
         trees/numerical_splliter.h trees/splitter.h types.h)
+set_target_properties(microgbt PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 
 
 target_sources(


### PR DESCRIPTION
Changelog:
* Make c++ cmake library static
* force python3.6 in cmake to avoid `undefined symbol: _Py_ZeroStruct` errors
* minor fixes in cmake